### PR TITLE
Null check when valve pipes start leaking on server.

### DIFF
--- a/src/main/java/flaxbeard/steamcraft/tile/TileEntityValvePipe.java
+++ b/src/main/java/flaxbeard/steamcraft/tile/TileEntityValvePipe.java
@@ -181,30 +181,29 @@ public class TileEntityValvePipe extends TileEntitySteamPipe {
 
             ArrayList<ForgeDirection> myDirections = new ArrayList<ForgeDirection>();
             for (ForgeDirection direction : directions) {
-                if (worldObj.getTileEntity(xCoord + direction.offsetX, yCoord + direction.offsetY, zCoord + direction.offsetZ) != null) {
-                    TileEntity tile = worldObj.getTileEntity(xCoord + direction.offsetX, yCoord + direction.offsetY, zCoord + direction.offsetZ);
+            	final TileEntity tile = worldObj.getTileEntity(xCoord + direction.offsetX, yCoord + direction.offsetY, zCoord + direction.offsetZ);
+                if (tile != null) {
                     if (tile instanceof ISteamTransporter) {
-                        ISteamTransporter target = (ISteamTransporter) tile;
+                        final ISteamTransporter target = (ISteamTransporter) tile;
                         if (target.doesConnect(direction.getOpposite())) {
                             myDirections.add(direction);
                         }
                     } else if (tile instanceof IFluidHandler && Steamcraft.steamRegistered) {
-                        IFluidHandler target = (IFluidHandler) tile;
+                        final IFluidHandler target = (IFluidHandler) tile;
                         if (target.canDrain(direction.getOpposite(), FluidRegistry.getFluid("steam")) || target.canFill(direction.getOpposite(), FluidRegistry.getFluid("steam"))) {
                             myDirections.add(direction);
                         }
                     }
                 }
             }
-            i = 0;
+            
             if (myDirections.size() > 0) {
                 ForgeDirection direction = myDirections.get(0).getOpposite();
                 while (!this.doesConnect(direction)) {
                     direction = ForgeDirection.getOrientation((direction.flag + 1) % 5);
                 }
 
-
-                if (myDirections.size() == 2 && open && this.getNetwork().getSteam() > 0 && i < 10 && (worldObj.isAirBlock(xCoord + direction.offsetX, yCoord + direction.offsetY, zCoord + direction.offsetZ) || !worldObj.isSideSolid(xCoord + direction.offsetX, yCoord + direction.offsetY, zCoord + direction.offsetZ, direction.getOpposite()))) {
+                if (myDirections.size() == 2 && open && this.getNetwork() != null && this.getNetwork().getSteam() > 0 && (worldObj.isAirBlock(xCoord + direction.offsetX, yCoord + direction.offsetY, zCoord + direction.offsetZ) || !worldObj.isSideSolid(xCoord + direction.offsetX, yCoord + direction.offsetY, zCoord + direction.offsetZ, direction.getOpposite()))) {
                     ////Steamcraft.log.debug("open and should be leaking");
                     if (!isLeaking) {
                         isLeaking = true;


### PR DESCRIPTION
Server crash when attaching a valve pipe to a new flash boiler built where a smaller setup had previously been.
```
Time: 1/7/15 6:18 PM
Description: Ticking block entity

java.lang.NullPointerException: Ticking block entity
    at flaxbeard.steamcraft.tile.TileEntityValvePipe.func_145845_h(TileEntityValvePipe.java:207)
    at net.minecraft.world.World.func_72939_s(World.java:1939)
    at net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:489)
    at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:636)
    at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:334)
    at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547)
    at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427)
    at net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)
```
Added a null check for the steam network (only place I saw that could NPE) and did some minor cleanup in the general vicinity.