### PR TITLE
Update SteamNetwork.java

### DIFF
--- a/src/main/java/flaxbeard/steamcraft/api/steamnet/SteamNetwork.java
+++ b/src/main/java/flaxbeard/steamcraft/api/steamnet/SteamNetwork.java
@@ -53,6 +53,7 @@ public class SteamNetwork {
     }
 
     public synchronized static SteamNetwork newOrJoin(ISteamTransporter trans) {
+        if (isClosedValvePipe(trans)) { return null; }
         HashSet<ISteamTransporter> others = getNeighboringTransporters(trans);
         HashSet<SteamNetwork> nets = new HashSet();
         SteamNetwork theNetwork = null;


### PR DESCRIPTION
Related to the non-reliable pipe valves reported various times before and in issue #186
This should fix the problem as closed steam valves will no longer join existing steam networks or create own networks. Had no chance to test this in MP so far, but works fine in solo play and with complex steam networks.